### PR TITLE
build: make clientmod optional in the build step

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,7 +60,17 @@ include(":service.elections")
 include(":service.guild")
 include(":service.store")
 include(":anticheat")
-include(":clientmod")
+
+val clientModRequested = gradle.startParameter.taskNames.any { taskName ->
+    taskName == "clientmod" ||
+        taskName == ":clientmod" ||
+        taskName.startsWith("clientmod:") ||
+        taskName.startsWith(":clientmod:")
+}
+
+if (clientModRequested || gradle.startParameter.projectProperties.containsKey("includeClientmod")) {
+    include(":clientmod")
+}
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
this will optimize build times when it's not required