### PR TITLE
Fix severe TPS drop caused by uncached SkillCategory.getRewards()

### DIFF
--- a/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/skill/SkillLoader.java
+++ b/type.skyblockgeneric/src/main/java/net/swofty/type/skyblockgeneric/skill/SkillLoader.java
@@ -88,13 +88,18 @@ public class SkillLoader {
                     return config.description;
                 }
 
+                private SkillReward[] cachedRewards = null;
+
                 @Override
                 public SkillReward[] getRewards() {
-                    List<SkillReward> rewards = new ArrayList<>();
-                    for (SkillRewardEntry entry : config.rewards) {
-                        rewards.add(parseReward(entry));
+                    if (cachedRewards == null) {
+                        List<SkillReward> rewards = new ArrayList<>();
+                        for (SkillRewardEntry entry : config.rewards) {
+                            rewards.add(parseReward(entry));
+                        }
+                        cachedRewards = rewards.toArray(new SkillReward[0]);
                     }
-                    return rewards.toArray(new SkillReward[0]);
+                    return cachedRewards;
                 }
             };
         } catch (Exception e) {


### PR DESCRIPTION
getRewards() rebuilt the entire reward list from config on every call, including every tick from the tablist module's XP calculation. This caused sustained ~0.5 TPS on SkyBlock Island. Caches the computed array since config never changes after initial load.